### PR TITLE
Fix import error

### DIFF
--- a/dsgrid/dataformat/sectordataset.py
+++ b/dsgrid/dataformat/sectordataset.py
@@ -3,7 +3,6 @@ from distutils.version import StrictVersion
 from itertools import repeat
 import h5py
 import logging
-from h5pyd._hl.files import is_hdf5
 import numpy as np
 import pandas as pd
 


### PR DESCRIPTION
This import failed on a new install with Python 3.9. is_hdf5 is never called and so can be removed.