### PR TITLE
Cache intermediate dfs in memory

### DIFF
--- a/bin/convert_commercial.sh
+++ b/bin/convert_commercial.sh
@@ -5,17 +5,13 @@
 
 # If running on Eagle:
 # - Make sure you change to /tmp/scratch and run from there.
-# - If $SPARK_HOME is not set then set it to the pyspark directory and create $SPARK_HOME/conf.
 # - Example:
-#       export SPARK_HOME=$HOME/.conda/envs/dsgrid/lib/python3.8/site-packages/pyspark
-# - Set this parameter in $SPARK_HOME/conf/spark-defaults.conf
-#       spark.driver.memory 80
+#       export SPARK_SETTINGS="--conf spark.driver.memory=80g"
 # - Set this parameter in $SPARK_HOME/conf/log4j.properties:
 #       log4j.rootCategory=WARN, console
 
 BIN_DIR=`dirname $0`
 OUTPUT_DIR=converted_output
-SPARK_SETTINGS="--conf spark.driver.extraJavaOptions=\"-Dio.netty.tryReflectionSetAccessible=true\" --conf spark.executor.extraJavaOptions=\"-Dio.netty.tryReflectionSetAccessible=true\""
 export SPARK_LOCAL_DIRS=`pwd`
 
 if [ -z $DSG_INPUTS ]; then
@@ -28,14 +24,18 @@ if [ -z $OUTPUT_DIR ]; then
 	exit 1
 fi
 
-spark-submit ${SPARK_SETTINGS} ${BIN_DIR}/convert_dsg.py -s sector_subsector --num-buckets=6 ${DSG_INPUTS}/commercial.dsg ${OUTPUT_DIR}
+spark-submit ${SPARK_SETTINGS} \
+    ${BIN_DIR}/convert_dsg.py \
+    --num-partitions 6 \
+    -s sector_subsector \
+    ${DSG_INPUTS}/commercial.dsg \
+    ${OUTPUT_DIR}
 
 if [ $? -ne 0 ]; then
 	echo "Creation of commercial parquet files failed: $?"
 	exit 1
 fi
 
-# Bucketing is not required here.
 # There are 16704 dataframes in commercial.dsg; start at the next one.
 grep "Last data_id=16704" ${OUTPUT_DIR}/commercial/convert_dsg.log >> /dev/null
 
@@ -44,7 +44,13 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-spark-submit ${SPARK_SETTINGS} ${BIN_DIR}/convert_dsg.py -s sector_subsector --data-id-offset=16704 ${DSG_INPUTS}/residential.dsg ${OUTPUT_DIR}
+spark-submit ${SPARK_SETTINGS} \
+    ${BIN_DIR}/convert_dsg.py \
+    --num-partitions 1 \
+    -s sector_subsector \
+    --data-id-offset=16704 \
+    ${DSG_INPUTS}/residential.dsg \
+    ${OUTPUT_DIR}
 
 if [ $? -ne 0 ]; then
 	echo "Creation of residential parquet files failed: $?"


### PR DESCRIPTION
This improves performance and prevents Spark memory errors from happening in certain situations. It fixes the issues seen by @mooneyme yesterday while converting distributedpv_sectoral.dsg.

@mooneyme The following command took ~2 minutes on my laptop. Run in local mode. There was nothing unusual about this dataset. I don't know why things were failing now when they didn't fail before. In any case, this solution is much better.
```
spark-submit --driver-memory 16G convert_dsg.py data/distributedpv_sectoral.dsg output -s sector -n 2
```